### PR TITLE
Update Usage Section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,7 @@ There is nothing special to do in the controller.  With the model binder registe
 
 #### In the view
 
-MVC will automatically call MvcEnumFlags to display enum types you've registered in **global.asax.cs** when you use `Html.EditorFor()`.
-
-The following is an example of displaying the flags checkbox with a registered enum.
+The following is an example of displaying the flags checkbox with a registered enum:
 ```
-@Html.EditorFor(model => model.MyEnumTypeProperty)
+@Html.CheckBoxesForEnumFlagsFor(model => model.MyEnumTypeProperty)
 ```


### PR DESCRIPTION
Thanks for this project - it saved me a lot of time writing the editors for flag enums!

I wasn't able to get the `@Html.EditorFor()` approach working in the views I had and can't see anywhere in the code where the binder would be linking to the `CheckBoxesForEnumFlagsFor` method. Am I missing something or does the `EditorFor` approach just not work? Would it even be possible to provide an override of `EditorFor` specifically for flag enums?